### PR TITLE
Fix main

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "plugin",
     "remove"
   ],
+  "main": "dist/index.js",
   "exports": "./dist/index.js",
   "type": "module",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
the following message was occured when test rehype-split-paragraph jest.

> Cannot find module 'rehype-remove-empty-paragraph' from 'src/split.ts'

https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#gistcomment-3719457
